### PR TITLE
Add CI, using GitHub Actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Admins should have oversight of the version:
+lib/ndr_pseudonymise/version.rb      @publichealthengland/ndr-admins

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on: [pull_request]
+
+jobs:
+  rubocop:
+    name: RuboCop
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0 # fetch everything
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0
+    - name: Install dependencies
+      run: bundle install
+    - name: Run RuboCop against BASE..HEAD changes
+      run: bundle exec rake rubocop:diff origin/${GITHUB_BASE_REF#*/}
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,72 @@
+name: Test
+
+on: [push]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        ruby-version:
+          - 2.6
+          - 2.7
+          - 3.0
+        gemfile:
+          - gemfiles/Gemfile.rails52
+          - gemfiles/Gemfile.rails60
+          - gemfiles/Gemfile.rails61
+
+    name: Ruby ${{ matrix.ruby-version }} / Bundle ${{ matrix.gemfile }}
+
+    runs-on: ubuntu-latest
+
+    env:
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+    - name: Install dependencies
+      run: bundle install
+    - name: Run tests
+      run: bundle exec rake
+
+  # A utility job upon which Branch Protection can depend,
+  # thus remaining agnostic of the matrix.
+  test_matrix:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Matrix
+    needs: test
+    steps:
+    - name: Check build matrix status
+      if: ${{ needs.test.result != 'success' }}
+      run: exit 1
+
+  notify:
+    # Run only on master, but regardless of whether tests past:
+    if: ${{ always() && github.ref == 'refs/heads/master' }}
+
+    needs: test_matrix
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: 8398a7/action-slack@v3
+      with:
+        status: custom
+        fields: workflow,commit,author
+        custom_payload: |
+          {
+            channel: 'C7FQWGDHP',
+            username: 'CI – ' + '${{ github.repository }}'.split('/')[1],
+            icon_emoji: ':hammer_and_wrench:',
+            attachments: [{
+              color: '${{ needs.test_matrix.result }}' === 'success' ? 'good' : '${{ needs.test_matrix.result }}' === 'failure' ? 'danger' : 'warning',
+              text: `${process.env.AS_WORKFLOW} against \`${{ github.ref }}\` (${process.env.AS_COMMIT}) for ${{ github.actor }} resulted in *${{ needs.test_matrix.result }}*.`
+            }]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,2 @@
-inherit_from: 'https://raw.githubusercontent.com/PublicHealthEngland/ndr_dev_support/master/.rubocop.yml'
+require:
+  - ndr_dev_support

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NdrPseudonymise
+## NdrPseudonymise [![Build Status](https://github.com/publichealthengland/ndr_pseudonymise/workflows/Test/badge.svg)](https://github.com/publichealthengland/ndr_pseudonymise/actions?query=workflow%3Atest)
 
 Pseudonymise confidential data, in CSV format, with specifications for which fields to be encrypted.
 

--- a/gemfiles/Gemfile.rails52
+++ b/gemfiles/Gemfile.rails52
@@ -2,5 +2,5 @@ source 'https://rubygems.org'
 
 gemspec path: '..'
 
-gem 'rails', '~> 5.0.0'
+gem 'rails', '~> 5.2.0'
 

--- a/gemfiles/Gemfile.rails60
+++ b/gemfiles/Gemfile.rails60
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails', '~> 6.0.0'
+

--- a/gemfiles/Gemfile.rails61
+++ b/gemfiles/Gemfile.rails61
@@ -2,5 +2,5 @@ source 'https://rubygems.org'
 
 gemspec path: '..'
 
-gem 'rails', '~> 4.2.0'
+gem 'rails', '~> 6.1.0'
 

--- a/ndr_pseudonymise.gemspec
+++ b/ndr_pseudonymise.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'minitest', '>= 5.0'
   spec.add_development_dependency 'mocha'
-  spec.add_development_dependency 'ndr_dev_support', '>= 2.0'
+  spec.add_development_dependency 'ndr_dev_support', '>= 6.0'
   spec.add_development_dependency 'ndr_import'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '>= 10.0'


### PR DESCRIPTION
This PR introduces the use of GitHub Actions for CI, in line with NDR's other open-source projects.

It tests against modern Ruby + Rails versions, and runs linting against submitted pull requests.