### PR TITLE
Fix concurrent-ruby version to 1.3.4 for older Rails versions

### DIFF
--- a/gemfiles/Gemfile.rails52
+++ b/gemfiles/Gemfile.rails52
@@ -4,3 +4,6 @@ gemspec path: '..'
 
 gem 'rails', '~> 5.2.0'
 
+
+# Latest concurrent-ruby breaks Rails < 7.1. See https://github.com/rails/rails/issues/54260
+gem 'concurrent-ruby', '1.3.4'

--- a/gemfiles/Gemfile.rails60
+++ b/gemfiles/Gemfile.rails60
@@ -4,3 +4,6 @@ gemspec path: '..'
 
 gem 'rails', '~> 6.0.0'
 
+
+# Latest concurrent-ruby breaks Rails < 7.1. See https://github.com/rails/rails/issues/54260
+gem 'concurrent-ruby', '1.3.4'

--- a/gemfiles/Gemfile.rails61
+++ b/gemfiles/Gemfile.rails61
@@ -4,3 +4,6 @@ gemspec path: '..'
 
 gem 'rails', '~> 6.1.0'
 
+
+# Latest concurrent-ruby breaks Rails < 7.1. See https://github.com/rails/rails/issues/54260
+gem 'concurrent-ruby', '1.3.4'

--- a/gemfiles/Gemfile.rails70
+++ b/gemfiles/Gemfile.rails70
@@ -3,3 +3,6 @@ source 'https://rubygems.org'
 gemspec path: '..'
 
 gem 'rails',  '~> 7.0.0'
+
+# Latest concurrent-ruby breaks Rails < 7.1. See https://github.com/rails/rails/issues/54260
+gem 'concurrent-ruby', '1.3.4'


### PR DESCRIPTION
This resolves test failures for Rails 7.0, caused by recently released gems.