### PR TITLE
Tests should support Ruby 3.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on: [push]
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         ruby-version:
           - '2.6'
@@ -13,6 +14,7 @@ jobs:
           - '3.1'
           - '3.2'
           - '3.3'
+          - '3.4'
         gemfile:
           - gemfiles/Gemfile.rails52
           - gemfiles/Gemfile.rails60
@@ -32,9 +34,19 @@ jobs:
             gemfile: 'gemfiles/Gemfile.rails52'
           - ruby-version: '3.3'
             gemfile: 'gemfiles/Gemfile.rails52'
-          # rails 7.0 requires ruby >= 2.7
+          - ruby-version: '3.4'
+            gemfile: 'gemfiles/Gemfile.rails52'
+          # rails 6.0 requires ruby < 3.4
+          - ruby-version: '3.4'
+            gemfile: 'gemfiles/Gemfile.rails60'
+          # rails 6.1 requires ruby < 3.4
+          - ruby-version: '3.4'
+            gemfile: 'gemfiles/Gemfile.rails61'
+          # rails 7.0 requires ruby >= 2.7, < 3.4
           # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
           - ruby-version: '2.6'
+            gemfile: 'gemfiles/Gemfile.rails70'
+          - ruby-version: '3.4'
             gemfile: 'gemfiles/Gemfile.rails70'
           # Only test rails 7.1 with ruby >= 3.1
           # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
 ## Fixed
-* Tests should support Rails 7.0, 7.1, 7.2, 8.0
+* Tests should support Rails 7.0, 7.1, 7.2, 8.0, Ruby 3.4
 * Remove hidden Rails gemfile dependency
 
 ## Added

--- a/test/unit/issue4810_test.rb
+++ b/test/unit/issue4810_test.rb
@@ -122,12 +122,12 @@ class Issue4810Test < ActiveSupport::TestCase
   end
 
   test 'pseudonymise_row' do
-    # TODO: Test with / without encrypt_clinical option (here or 2 test methods)
+    skip 'TODO: Test with / without encrypt_clinical option (here or 2 test methods)'
   end
 
   test 'row_errors' do
-    # TODO: Test validations
-    # TODO: Test rows with too many columns (excluding extra blank data)
+    skip 'TODO: Test validations'
+    skip 'TODO: Test rows with too many columns (excluding extra blank data)'
   end
 
   # def encrypt

--- a/test/unit/ndr_pseudonymise_test.rb
+++ b/test/unit/ndr_pseudonymise_test.rb
@@ -117,12 +117,12 @@ class NdrPseudonymiseTest < ActiveSupport::TestCase
   end
 
   test 'pseudonymise_row' do
-    # TODO: Test with / without encrypt_clinical option (here or 2 test methods)
+    skip 'TODO: Test with / without encrypt_clinical option (here or 2 test methods)'
   end
 
   test 'row_errors' do
-    # TODO: Test validations
-    # TODO: Test rows with too many columns (excluding extra blank data)
+    skip 'TODO: Test validations'
+    skip 'TODO: Test rows with too many columns (excluding extra blank data)'
   end
 
   # def encrypt

--- a/test/unit/pseudonymisation_specification_test.rb
+++ b/test/unit/pseudonymisation_specification_test.rb
@@ -120,12 +120,12 @@ class PseudonymisationSpecificationTest < ActiveSupport::TestCase
   end
 
   test 'pseudonymise_row' do
-    # TODO: Test with / without encrypt_clinical option (here or 2 test methods)
+    skip 'TODO: Test with / without encrypt_clinical option (here or 2 test methods)'
   end
 
   test 'row_errors' do
-    # TODO: Test validations
-    # TODO: Test rows with too many columns (excluding extra blank data)
+    skip 'TODO: Test validations'
+    skip 'TODO: Test rows with too many columns (excluding extra blank data)'
   end
 
   # def encrypt

--- a/test/unit/simple_pseudonymisation_test.rb
+++ b/test/unit/simple_pseudonymisation_test.rb
@@ -81,7 +81,7 @@ class SimplePseudonymisationTest < ActiveSupport::TestCase
     assert_equal(encrypted_data64,
                  NdrPseudonymise::SimplePseudonymisation.encrypt_data64(key, data))
     encrypted_data_to_compare = if encrypted_data.respond_to?(:force_encoding)
-                                  encrypted_data.force_encoding('ASCII-8BIT')
+                                  encrypted_data.dup.force_encoding('ASCII-8BIT')
                                 else
                                   encrypted_data
                                 end


### PR DESCRIPTION
Test `ndr_pseudonymise` gem with Ruby 3.4. (The gem already supports it; the only changes needed were to the tests.)

Our rubocop automated lint diffing fails on this PR because of the control characters in `test/unit/simple_pseudonymisation_test.rb`, but the file itself rubocops OK, and this PR introduces no new warnings.